### PR TITLE
Fixed import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "com.leopotam.ecs.remotedebug",
+    "name": "com.leopotam.ecs-remotedebug",
     "author": "Leopotam",
     "displayName": "LeoECS RemoteDebug",
     "description": "LeoECS RemoteDebug connector for LeoECS Entity Component System framework.",


### PR DESCRIPTION
"com.leopotam.ecs"
"com.leopotam.ecs-ui"
"com.leopotam.ecs-unityintegration"
"com.leopotam.ecs.remotedebug" -> "com.leopotam.ecs-remotedebug"

Была неконсистентность нейминга, а в ридми "-", не импортилось через манифест